### PR TITLE
Dump raw events

### DIFF
--- a/decoders/decodeGBT_32bit.py
+++ b/decoders/decodeGBT_32bit.py
@@ -24,6 +24,17 @@ def main(argv):
     datafile = open(args.ifile, 'r')
     decodedfile = open(args.ofile, 'w')
 
+    # option to dump raw events
+    if args.dfile:
+        dfile = open(args.dfile, 'r').readlines()
+        events_to_dump = []
+        for df in dfile:
+            if not df:
+                continue
+            df = df.strip()
+            events_to_dump.append(int(df))
+        events_to_dump = sorted(list(set(events_to_dump)))
+
     lines = []
 
     # previous bcids
@@ -56,7 +67,7 @@ def main(argv):
             continue
         lines.append(line[:len(line)-1])
 
-        if iline % 50000 == 0 and iline > 0:
+        if iline % 50000 == 0 and iline > 0 and not args.dfile:
             visual.pbftp(time.time() - start_time, iline, num_lines)
 
         n = 5 # start pt of data
@@ -117,8 +128,11 @@ def main(argv):
                 #print "Event", nevent
                 Aflag = True
                 buflen = 0
-                    
-                decodedfile.write("Event " + str(nevent) +" Sec " + str(timestampsec) + " NS " + str(timestampns) + "\n")
+
+                write_me = "Event " + str(nevent) +" Sec " + str(timestampsec) + " NS " + str(timestampns) + "\n"
+                decodedfile.write(write_me)
+                if args.dfile and nevent in events_to_dump:
+                    print write_me.rstrip("\n")
 
             if (Aflag):
                 addc1 = int(bcid,16)
@@ -141,6 +155,8 @@ def main(argv):
                             arts.append([vmm,art])
                     write_me = "%s %s" % (ibo, " ".join(["%s,%s" % (vmm, art) for vmm,art in arts]))
                     decodedfile.write(write_me+"\n")
+                if args.dfile and nevent in events_to_dump:
+                    print "\n".join(lines)
             lines = []
             
     decodedfile.close()
@@ -160,6 +176,7 @@ def options():
     parser = argparse.ArgumentParser()
     parser.add_argument("--ifile", "-i", default="", help="input file")
     parser.add_argument("--ofile", "-o", default="", help="output file")
+    parser.add_argument("--dfile", "-d", default="", help="input file of event numbers to dump")
     return parser.parse_args()
     
 if __name__ == "__main__":

--- a/tp_fidelity.py
+++ b/tp_fidelity.py
@@ -8,7 +8,7 @@ tp_fidelity.py -- a script to test self-consistency of the TP output.
 4. Check if the fit is missing any hits which should be there (IN PROGRESS. PRETTY HARD.)
 
 run like:
-> python tp_fidelity.py --fit fit.decode.dat --gbt gbt.decode.dat
+> python tp_fidelity.py --fit fit.decode.dat --gbt gbt.decode.dat [ --ignore-slope ]
 
 """
 
@@ -52,7 +52,7 @@ def main():
 
         mxl_offline = fitpk.mxl_offline()
 
-        if mxl_offline != fitpk.mxl:
+        if mxl_offline != fitpk.mxl and not ops.ignore_slope:
             if abs(int(mxl_offline, base=16) - int(fitpk.mxl, base=16)) == 1:
                 # off by 1: probably just rounding
                 pass
@@ -354,6 +354,7 @@ def options():
     parser = argparse.ArgumentParser(usage=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--gbt", default="mmtp_test_21.decode.dat", help="Input GBT decoded dat file")
     parser.add_argument("--fit", default="mmtp_test_22.decode.dat", help="Input FIT decoded dat file")
+    parser.add_argument("--ignore-slope", action="store_true", default=False, help="Disable slope check, if desired")
     return parser.parse_args()
 
 


### PR DESCRIPTION
@SEZATA 

I don't remember why, but I had previously disable the occupancy warning for slopes in decodeFIT_uvr.py. When I run on 3556 with this enabled, every event has a warning. Does that ring any bells? I don't remember this at all.