### PR TITLE
Make files globally accessible, and make keyboard interrupt more effective

### DIFF
--- a/udpReceive_32bit_MP.py
+++ b/udpReceive_32bit_MP.py
@@ -25,7 +25,7 @@ nProc = 1
 
 
 debug = False
-useTestInput = True
+useTestInput = False
 inputRate = 1000 #Hz
 
 printingSleep = 1 #s


### PR DESCRIPTION
For some reason, when the open text files were passed to processPacket, they were seen as closed within the function. Like, if I did "print files" before calling processPacket, and then "print files" from within processPacket, the first print yielded open files and the second print yielded closed files. Very weird. And confusing - didn't we see the output files being written correctly at some point?

But okay, the workaround was simple - open the files globally, and let the functions write to them without needing to be passed as arguments.

I also found some links for making the keyboard interrupt more effective, both for processPacket and for the threading.Timer:

https://stackoverflow.com/questions/1408356/
https://stackoverflow.com/questions/5952910/

All things considered, this writes to file and exits gracefully with 10k input rate of fake data.